### PR TITLE
Fix rule handler

### DIFF
--- a/h5p-show-when.js
+++ b/h5p-show-when.js
@@ -64,7 +64,7 @@ H5PEditor.ShowWhen = (function ($) {
         }
       }
 
-      return false;
+      return (type === TYPE_AND);
     };
   }
 

--- a/h5p-show-when.js
+++ b/h5p-show-when.js
@@ -51,9 +51,7 @@ H5PEditor.ShowWhen = (function ($) {
     };
 
     // Check if rules are satisfied
-    this.rulesSatisfied = function (ruleslength) {
-      // Initialize the number of rules in a TYPE_AND field
-      var andRulesNb = 0;
+    this.rulesSatisfied = function () {
       for (var i = 0; i < handlers.length; i++) {
         // check if rule was hit
         var ruleHit = handlers[i].satisfied();
@@ -61,12 +59,8 @@ H5PEditor.ShowWhen = (function ($) {
         if (ruleHit && type === TYPE_OR) {
           return true;
         }
-        else if (type === TYPE_AND && ruleHit) {
-            // Increment the number of rules in a TYPE_AND field.
-            andRulesNb ++
-            if (andRulesNb === ruleslength) {
-              return true;
-            }
+        else if (type === TYPE_AND && !ruleHit) {
+          return false;
         }
       }
 
@@ -95,14 +89,11 @@ H5PEditor.ShowWhen = (function ($) {
     }
 
     var ruleHandler = new RuleHandler(config.type);
-    // Get the number of rules in a TYPE_AND field.
-    var ruleslength = config.rules.length;
-    
+
     for (var i = 0; i < config.rules.length; i++) {
       var rule = config.rules[i];
       var targetField = H5PEditor.findField(rule.field, parent);
-      // Pass the ruleslength value to the handler
-      var handler = createFieldHandler(targetField, rule.equals, ruleslength);
+      var handler = createFieldHandler(targetField, rule.equals);
 
       if (handler !== undefined) {
         ruleHandler.add(handler);
@@ -117,8 +108,7 @@ H5PEditor.ShowWhen = (function ($) {
             }
           }
         } : function () {
-          // Pass the ruleslength value to "showing".
-          showing = ruleHandler.rulesSatisfied(ruleslength);
+          showing = ruleHandler.rulesSatisfied();
           $wrapper.toggleClass('hidden', !showing);
         });
       }

--- a/h5p-show-when.js
+++ b/h5p-show-when.js
@@ -51,7 +51,9 @@ H5PEditor.ShowWhen = (function ($) {
     };
 
     // Check if rules are satisfied
-    this.rulesSatisfied = function () {
+    this.rulesSatisfied = function (ruleslength) {
+      // Initialize the number of rules in a TYPE_AND field
+      var andRulesNb = 0;
       for (var i = 0; i < handlers.length; i++) {
         // check if rule was hit
         var ruleHit = handlers[i].satisfied();
@@ -59,8 +61,12 @@ H5PEditor.ShowWhen = (function ($) {
         if (ruleHit && type === TYPE_OR) {
           return true;
         }
-        else if (type === TYPE_AND && !ruleHit) {
-          return false;
+        else if (type === TYPE_AND && ruleHit) {
+            // Increment the number of rules in a TYPE_AND field.
+            andRulesNb ++
+            if (andRulesNb === ruleslength) {
+              return true;
+            }
         }
       }
 
@@ -89,11 +95,14 @@ H5PEditor.ShowWhen = (function ($) {
     }
 
     var ruleHandler = new RuleHandler(config.type);
-
+    // Get the number of rules in a TYPE_AND field.
+    var ruleslength = config.rules.length;
+    
     for (var i = 0; i < config.rules.length; i++) {
       var rule = config.rules[i];
       var targetField = H5PEditor.findField(rule.field, parent);
-      var handler = createFieldHandler(targetField, rule.equals);
+      // Pass the ruleslength value to the handler
+      var handler = createFieldHandler(targetField, rule.equals, ruleslength);
 
       if (handler !== undefined) {
         ruleHandler.add(handler);
@@ -108,7 +117,8 @@ H5PEditor.ShowWhen = (function ($) {
             }
           }
         } : function () {
-          showing = ruleHandler.rulesSatisfied();
+          // Pass the ruleslength value to "showing".
+          showing = ruleHandler.rulesSatisfied(ruleslength);
           $wrapper.toggleClass('hidden', !showing);
         });
       }


### PR DESCRIPTION
The problem with the rule handler was the default return value that was returned when no rule lead to an early resolution. It was always `false` while it should have been `true` for rules of _AND_ type and only `false` for rules of _OR_ type. Fixed here.